### PR TITLE
top note now warning

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-.. note::
+.. warning::
 
    This page is currently (June 22, 2022) a test page.  It may be come the real user-facing documentation for Nightingale, if that happens, this notice will be removed.
 


### PR DESCRIPTION
Changing the syntax of the top box on the table (the one saying "this is not the real Nightingale documentation") a warning (orange box) instead of "note" (blue box).