### PR TITLE
fix missing .ngale.

### DIFF
--- a/docs/source/accessing_the_system/index.rst
+++ b/docs/source/accessing_the_system/index.rst
@@ -209,7 +209,7 @@ you're typing, substitute the hostname of **your** nightingale node for
 
 ::
 
-   ssh -J UUUUU@ngale-bastion-1.ncsa.illinois.edu UUUUU@XXXXX.internal.ncsa.edu
+   ssh -J UUUUU@ngale-bastion-1.ncsa.illinois.edu UUUUU@XXXXX.ngale.internal.ncsa.edu
    
 
 so with the proper substitutions, if fictional user Hiro P. were using
@@ -218,7 +218,7 @@ they would type the following:
 
 ::
 
-   ssh -J hirop@ngale-bastion-1.ncsa.illinois.edu hirop@beatlesGPU02.internal.ncsa.edu
+   ssh -J hirop@ngale-bastion-1.ncsa.illinois.edu hirop@beatlesGPU02.ngale.internal.ncsa.edu
    
 
 The text will ask you for your password. Type in your NCSA kerberos


### PR DESCRIPTION
A couple of places, I (Craig) put URLs in ssh examples that left out the "ngale" segment in the internal host references, which made the examples not work.  This change may get rid of the only one, but we'll need to keep an eye out for that.

Searching in the document nreadthedocs.com, I only found two URLs that ended in "internal.ncsa.edu".  One of them already had the .ngale. properly as part of the URL, this one didn't. 