### PR TITLE
Change rollup for December 1 training

### DIFF
--- a/docs/source/accessing/logging_in.rst
+++ b/docs/source/accessing/logging_in.rst
@@ -42,29 +42,21 @@ Below is a sample SSH command line to log into Nightingale's secure node where <
 
    ssh <username>@ngale-bastion-1.ncsa.illinois.edu
 
-After entering the ssh command, you will be prompted to enter your password, followed by a prompt to send a push to the Duo app (both of which you will not see on the screen). After you have approved the push, you will be at a prompt on ngale-bastion-1 node that will look something like this: 
-
-.. 
+After entering the ssh command, you will be prompted to enter your password, followed by a prompt to send a push to the Duo app (both of which you will not see on the screen). After you have approved the push, you will be at a prompt on ngale-bastion-1 node that will look similar to::
 
    [csteffen@ngale-bastion-1 ~]$
 
-At that prompt, enter an SSH command using the hostname of your login node:
-
-.. 
+At the prompt, enter an SSH command using the hostname of your login node following this syntax:: 
 
    ssh <your_username>@ng-<yourgroup>01
    
-so for example, if your username is "hirop" and you group name is "biology" then your final ssh command might look like this:
-
-.. 
+For example, if your username is "hirop" and you group name is "biology" then your ssh command would look like this:: 
 
    ssh hirop@ng-biology03
    
 In this case, you would been specifically told that "ng-biology03" would be your node to use for your computations.
 
-The two commands above can be combined into one by specifying the bastion host as a "jump" host. The jump host is used to connect you to your destination node without you needing to interact with it. In this example, user "test1" can log into the Nightingale login node "login01" directly without logging into the bastion host first.
-
-.. 
+The two commands above can be combined into one by specifying the bastion host as a "jump" host. The jump host is used to connect you to your destination node without you needing to interact with it. In this example, user "test1" can log into the Nightingale login node "login01" directly without logging into the bastion host first.::
 
    ssh -J test1@ngale-bastion-1.ncsa.illinois.edu test1@ng-login01
 
@@ -73,7 +65,7 @@ The two commands above can be combined into one by specifying the bastion host a
 You must have an "NCSA" entry in your Duo app as follows.  A "University of Illinois" Duo entry will not get you into Nightingale.  
 
 .. image:: ./NCSA_duo_versC.gif
-   :scale: 40 %
+   :scale: 20 %
 
 **Passwords**
 

--- a/docs/source/accessing/ssh_clients.rst
+++ b/docs/source/accessing/ssh_clients.rst
@@ -1,7 +1,7 @@
 SSH Clients
 ===========
 
-SSH (Secure Shell) is an application that gives users a secure way to access a computer over an unsecured network. It allows them to log in to another computer over a network and execute commands on that machine. SSH provides strong authentication to prevent other from using their account, and it encrypts their data between computers connecting over an open network, such as the internet, so that it can’t be read by others.
+SSH (Secure Shell) is a client-server architecture that provides a secure channel over an unsecured network. An SSH client is a program for logging securely into and executing commands on a remote machine. SSH encrypts the data sent over an open network, such as the internet, so that it can’t be read by others.
 
 Several SSH-based clients are available for accessing Nightingale. Which one you use depends on your workstation’s operating 
 system. These are described in the sections below.

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -18,21 +18,28 @@ management with the ability to share and access relational databases on
 the system. With 880 TB of high-speed parallel Lustre-based storage, the
 system supports the researchers’ needs for sharing data and generating and storing results.
 
-Interactive Compute Nodes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Interactive Login Nodes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  4 interactive compute/login nodes with dual 64-core AMDs and 512 GB
-   of RAM
--  1 interactive node with 2 A100 GPUs, dual 32-core AMDs with 512GB RAM
--  1 interactive node with 1 A100 GPU, dual 32-core AMDs with 256GB RAM
--  5 interactive nodes with 1 A40 GPU, dual 32-core AMDs with 512GB RAM
+- 2 interactive dual 32-core AMD **login** nodes each with 512GB RAM (*no GPUs*)
 
-Batch Compute System
-~~~~~~~~~~~~~~~~~~~~~~~~
 
--  15 dual 64-core AMD systems with 1 TB of RAM
--  1 GPU compute node with 2 A100 GPUs, dual 32-core AMDs with 512GB RAM
--  4 GPU compute nodes with 1 A100 GPU, dual 32-core AMDs with 256GB RAM
+Interactive Group Nodes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- 2 interactive dual 32-core AMD **group** nodes each with 512GB RAM and 1 NVIDIA A40 GPU
+- 2 interactive dual 32-core AMD **group** nodes each with 512GB RAM and 2 NVIDIA A100 GPUs
+- 1 interactive dual 32-core AMD **group** node with 256GB RAM and 1 NVIDIA A100 GPU
+
+
+Batch/Interactive Compute Nodes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- 16 batch/interactive dual 32-core AMD **compute** nodes each with 1TB RAM (*no GPUs*)
+-  1 batch/interactive dual 32-core AMD **compute** node with 512GB RAM and 2 NVIDIA A100 GPUs
+-  5 batch/interactive dual 32-core AMD **compute** nodes each with 256GB RAM and 1 NVIDIA A100 GPU
+-  2 batch/interactive dual 32-core AMD **compute** nodes each with 512GB RAM and 1 NVIDIA A40 GPU
+
 
 Storage
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/citizenship.rst
+++ b/docs/source/citizenship.rst
@@ -14,4 +14,4 @@ Nightingale’s scheduling system is responsible for ensuring you have the resou
 
 **Use the login nodes responsibly**
 
-Nightingale’s login nodes are a shared resource for all users. You use them to conduct the activities necessary to prepare your applications, such as editing, compiling, building your programs, and short non-intensive runs. This is important to remember. It means that what you do on the login node can impact system performance and affect other users. System administrators may terminate your user processes if you negatively impact the system.
+Nightingale’s login nodes are a shared resource for all users. You use them to conduct the activities necessary to prepare your applications, such as editing, compiling, building your programs, and short non-intensive runs. This is important to remember. What you do on the login node can impact system performance and affect other users. System administrators may terminate your user processes if you negatively impact the system.

--- a/docs/source/containers.rst
+++ b/docs/source/containers.rst
@@ -2,4 +2,4 @@
 Containers
 ==========
 
-Because of the limitations of Nightingale nodes to access the external sites due to its increased security restrictions, containers are not generally supported on Nightingale. However, they may be used in limited use cases. If you need to use containers, please submit a ticket to Nightingale user support staff by emailing help@ncsa.illinois.edu, and we will talk to you about your options.  
+Because of the limitations of Nightingale nodes to access the external sites due to its increased security restrictions, containers are not generally supported on Nightingale. However, they may be used in limited use cases. If you need to use containers, please submit a ticket to Nightingale user support staff at :ref:`help` and we will talk to you about your options.  

--- a/docs/source/fee_overview.rst
+++ b/docs/source/fee_overview.rst
@@ -12,7 +12,7 @@ Access to an entire dedicated node with the number of users specified by the Pri
 
 **Option 2:** Per User on a Shared Node: $267.50 per month
 
-Access to a shared node with up to 5 users from across the system. Security between a user's files users from other groups is maintained with Unix directory permissions configured by the Lightweight Directory Access Protocol (LDAP). Users can access the node simultaneously. There is no “speed of service” guarantee, although the powerful nodes should be sufficient for most users. NCSA will consult with users who create a significant high load on the system – options such as reassigning nodes or requiring additional allocation will be determined on a case-by-case basis.
+Access to a shared node with up to 5 users from across the system. Security between a user's files and users from other groups is maintained with Unix directory permissions configured by the Lightweight Directory Access Protocol (LDAP). Users can access the node simultaneously. There is no “speed of service” guarantee, although the powerful nodes should be sufficient for most users. NCSA will consult with users who create a significant high load on the system – options such as reassigning nodes or requiring additional allocation will be determined on a case-by-case basis.
 
 Batch Computing Option
 ======================

--- a/docs/source/file_mgmt/editing_files.rst
+++ b/docs/source/file_mgmt/editing_files.rst
@@ -22,8 +22,8 @@ GNU nano is an easy-to-use command line text editor for Linux. To open an existi
    nano file_name
 
 This opens a new editor window in your terminal where you can start editing the file. At the bottom of the window, you will find a list of 
-shortcuts to use with the nano editor. The caret symbol (^) represents the Ctrl key (e.g., to exit, type Ctrl+X). The letter M represents the 
-Alt key (e.g., to undo type Alt+U).
+shortcuts to use with the nano editor. The caret symbol (^) represents the Ctrl key (e.g., to exit, Nano shows ^X, type Ctrl+X). The letter M represents the 
+Alt key (e.g., Nano shows M-U, to undo type Alt+U).
 
 MobaTextEditor
 ==============

--- a/docs/source/file_mgmt/filesystem.rst
+++ b/docs/source/file_mgmt/filesystem.rst
@@ -33,11 +33,11 @@ More information about these storage areas is described in the following section
  
 **Home**
 
-The /u area of the filesystem is where users land upon logging on to the cluster via SSH and is where a user’s $HOME environment variable points. This area has a fairly small quota and is meant to contain a user’s configuration files, job output/error files, and smaller software installations. This area is automatically set up during the account provisioning process and there is no additional charge for this storage. It is not possible to request an expansion of the home directory quota. If a user depletes the available space on their home directory, they will be notified and given the opportunity to remove files from it. At some point, system administrators will clear the data to get below the quota  threshold.
+The /u area of the filesystem is where users land upon logging on to the cluster  and is where a user’s $HOME environment variable points. This area has a fairly small quota and is meant to contain a user’s configuration files, job output/error files, and smaller software installations. This area is automatically set up during the account provisioning process and there is no additional charge for this storage. It is not possible to request an expansion of the home directory quota. If a user depletes the available space on their home directory, they will be notified and given the opportunity to remove files from it. You will need to delete files to get below the threshold and will not be able to store additional data.
 
 **Project**
 
-The /projects area of the filesystem is where members of a group (be they a single faculty member, a lab group, a department, or an entire college) store their project-related files. A user can have access to multiple project subdirectories if they are a member of various groups and have been granted access to the space by the project's Principal Investigator (PI). Projects pay a separate charge for this project space and the minimum allocation is 1 TB. Additional space can be purchased as needed.
+The /projects area of the filesystem is where group members (be they a single faculty member, a lab group, a department, or an entire college) store their project-related files. A user can have access to multiple project subdirectories if they are a member of multiple groups and have been granted access to the space by the project's Principal Investigator (PI). Projects pay a separate charge for this project space and the minimum allocation is 1 TB. Additional space can be purchased as needed.
 
 **User Scratch**
 

--- a/docs/source/file_mgmt/globus.rst
+++ b/docs/source/file_mgmt/globus.rst
@@ -18,7 +18,7 @@ Using Globus to Transfer Files
 
 Once your identity is linked (above) then do the following to transfer files using Globus.
 
-Navigate to globus.org and cling “Log In” in the upper right corner
+Navigate to globus.org and click “Log In” in the upper right corner
 
 Choose “National Center for Supercomputing Applications” as your Identity Provider and click “Continue”
 

--- a/docs/source/file_mgmt/index.rst
+++ b/docs/source/file_mgmt/index.rst
@@ -7,6 +7,5 @@ File Management
     
     filesystem
     transfer_files
-    globus
     editing_files
     organize_files

--- a/docs/source/file_mgmt/transfer_files.rst
+++ b/docs/source/file_mgmt/transfer_files.rst
@@ -5,7 +5,7 @@ Transferring Files
 Copying project data to your home directory
 ===========================================
 
-You will not work directly on your group's curated project data which is stored in the /datasets directory. Rather to work with them, you will need to copy the data from the original directory to your home directory.  Follow the steps below.
+You will not work directly on your group's curated project data in the /datasets directory. Instead, you will need to copy the data from the original directory to your home directory.  Follow the steps below.
 
 Enter the **cd** command to go your home directory::
 

--- a/docs/source/file_mgmt/transfer_files.rst
+++ b/docs/source/file_mgmt/transfer_files.rst
@@ -36,7 +36,7 @@ SCP requires a source and a destination. You can use it to copy individual files
 
 Since Nightingale has a bastion host which all network traffic travels through, you need to specify that the copy will jump through the bastion. For example, if user "test1" is copying file "my_data" from their current directory on their local machine to their home directory on the Nightingale login node "ng-login01" they would use the following command::
 
-   scp -J test1@ngale-bastion-1.ncsa.illinois.edu my_data test1@ng-login01
+   scp -J test1@ngale-bastion-1.ncsa.illinois.edu my_data test1@ng-login01:.
    
 Copying Files On To Nightingale Using AWS S3 Buckets
 ====================================================

--- a/docs/source/protected_data.rst
+++ b/docs/source/protected_data.rst
@@ -2,4 +2,4 @@
 Protected Data
 ==============
 
-Data stored on Nightingale may contain sensitive, regulated information. While Nightingale is set up to protect this data, users are directly responsible for protecting it. All downloads are monitored and will be investigated. If you need to download your results which don't contain sensitive data from Nightingale, submit a ticket to help@ncsa.illinois.edu detailing what data you need to download, why you need it, and how you intend to download it. You must wait for a response permitting you to do so before downloading it.  
+Data stored on Nightingale may contain sensitive, regulated information. While Nightingale is set up to protect this data, users are directly responsible for protecting it. All downloads are monitored and will be investigated.  If you need to download your results which don't contain sensitive data from Nightingale, submit a ticket (:ref:`help`) detailing what data you need to download, why you need it, and how you intend to download it. You must wait for a response permitting you to do so before downloading it.  

--- a/docs/source/running_jobs/index.rst
+++ b/docs/source/running_jobs/index.rst
@@ -8,4 +8,4 @@ Running Jobs
     introduction
     slurm
     interactive_jobs
-    sample_job_scripts
+  

--- a/docs/source/running_jobs/index.rst
+++ b/docs/source/running_jobs/index.rst
@@ -7,5 +7,5 @@ Running Jobs
 
     introduction
     slurm
-    interactive_jobs
+    
   

--- a/docs/source/running_jobs/index.rst
+++ b/docs/source/running_jobs/index.rst
@@ -2,8 +2,6 @@
 Running Jobs
 #############
 
-**UNDER CONSTRUCTION**
-
 .. toctree::
     :maxdepth: 1
 

--- a/docs/source/running_jobs/introduction.rst
+++ b/docs/source/running_jobs/introduction.rst
@@ -35,39 +35,4 @@ configured to write their results to a location on disk, and so you can
 retrieve the results and read them when you log into Nightingale the
 next time.
 
-This page is meant to teach you how to put together a job on
-Nightingale, submit it to the Nightingale job system, monitor the job
-before it runs, during its run, after it's finished, and then how to
-retrieve the results. Please see the example scripts page for scripts
-that work on Nightingale that you can use and build from.
 
-Nightingale Queues
-##################
-
-Users can view the partitions(queues) that they have the ability to submit batch jobs to, by typing the following command:
-::
-
-    [ng-login01 ~]$ sinfo -s -o "%.14R %.12l %.12L %.5D"
-    
-Users can also view specific configuration information about the compute nodes associated with their primary partition(s), by typing the following command:
-::
-
-    [ng-login01 ~]$ sinfo -p queue(partition)_name -N -o "%.8N %.4c %.16P %.9m %.12l %.12L %G"
-    
-The current limits in the Nightingale queues are below:
-
-================  ==========  ============  =======   ================  ============
-Queue(partition)  CPUs        Memory        Max #     GPUs              Max Walltime
-                  (per Node)  (per Node)    Nodes     Type : Count
-                                                      (per node)
-cpu               64	      1TB           16        n/a               7 days
-a40               64	      512GB         2         Tesla A40 : 1     7 days
-a100              64	      256GB         5         Tesla A100 : 1    7 days
-a100x2            64	      512GB         1         Tesla A100 : 2    7 days
-================  ==========  ============  =======   ================  ============
-
-This page and the example scripts page assume that you have a working
-knowledge of how to write and test a script, and you know at least
-generally how jobs work. If you don't, but you want to run software on
-compute nodes, the safest place to start is probably interactive jobs
-(below). Please send us a ticket if you need help with this.

--- a/docs/source/running_jobs/slurm.rst
+++ b/docs/source/running_jobs/slurm.rst
@@ -16,6 +16,16 @@ and for short non-intensive runs.
 To ensure the health of the batch system and scheduler users should refrain from having 
 more than 1,000 batch jobs in the queues at any one time.
 
+This page is meant to teach you how to put together a job on
+Nightingale, submit it to the Nightingale job system, monitor the job
+before it runs, during its run, after it has finished, and then how to
+retrieve the results. Please see the batch scripts below for working 
+examples that can be submitted on Nightingale. Additionally, the batch 
+scripts can be copied and modified to suit your specific needs.
+
+
+
+
 
 Running Programs
 ================
@@ -54,19 +64,28 @@ On successful building (compilation and linking) of your program, an executable 
 
 
 
-:raw-html:`<br />` If you want to run multiple copies of a program you can use the *srun* command followed by the name of the executable. 
-:raw-html:`<br />` :raw-html:`&nbsp`
-:raw-html:`<br />` Ex. 
-:raw-html:`<br />` :raw-html:`&nbsp` :raw-html:`&nbsp` :raw-html:`&nbsp` ``srun ./a.out``
-:raw-html:`<br />` :raw-html:`&nbsp`
-:raw-html:`<br />` **Note:** By default the total number of copies run, is equal to number cores specified in the batch job resource specification.
-:raw-html:`<br />` :raw-html:`&nbsp`
-:raw-html:`<br />` Users can use the *-n*  flag/option with the *srun* command to specify the number of copies of a program that they would like to run 
-:raw-html:`<br />` keeping in mind that the value for the *-n*  flag/option must be less than or equal to the number of cores specifed for the batch job.
-:raw-html:`<br />` :raw-html:`&nbsp`
-:raw-html:`<br />` Ex. 
-:raw-html:`<br />` :raw-html:`&nbsp` :raw-html:`&nbsp` :raw-html:`&nbsp` ``srun -n 10 ./a.out``
-:raw-html:`<br />` :raw-html:`&nbsp`
+Nightingale Queues
+==================
+
+    
+The current limits in the Nightingale queues are below:
+
+================  ==========  ============  =======   ================  ============
+Queue(partition)  CPUs        Memory        Max #     GPUs              Max Walltime
+                  (per Node)  (per Node)    Nodes     Type : Count
+                                                      (per node)
+cpu               64	      1TB           16        n/a               7 days
+a40               64	      512GB         2         Tesla A40 : 1     7 days
+a100              64	      256GB         5         Tesla A100 : 1    7 days
+a100x2            64	      512GB         1         Tesla A100 : 2    7 days
+================  ==========  ============  =======   ================  ============
+
+The information here and the example scripts assume that you have a working
+knowledge of how to write and test a script, and you have a general understanding
+of how jobs work. If you don't, but you want to run software on compute nodes, 
+the safest place to start is probably interactive batch jobs (below).  Please send
+us a ticket if you need help with this.
+
 
 Managing your jobs with Slurm
 =============================
@@ -75,17 +94,27 @@ Generally you'll use these commands to run **batch** jobs. Each batch
 job is controlled by a script that you hand off and the compute nodes
 run when there's enough nodes available to run. That is, the job will
 generally run **asynchronously**, so you can log back in and see the
-output when it's finished. For more detailed information, refer to the individual man pages.
+output when it's finished. For more detailed information, refer to the
+individual man pages.
 
 sbatch
 ------
 
-Batch jobs are submitted through a *job script* using the ``sbatch`` command. Job scripts generally start with a series of SLURM directives that describe requirements of the job such as number of nodes, wall time required, etc… to the batch system/scheduler (SLURM directives can also be specified as options on the sbatch command line; command line options take precedence over those in the script). The rest of the batch script consists of user commands.
+Batch jobs are submitted through a *batch script* using the ``sbatch``
+command. Batch scripts generally start with a series of SLURM directives
+that describe requirements of the job such as number of nodes, wall time
+required, etc… to the batch system/scheduler (SLURM directives can also
+be specified as options on the sbatch command line; command line options
+take precedence over those in the script). The rest of the batch script
+consists of user commands.
 
-Sample batch scripts are available on Nightingale in the directory ``/sw/apps/NUS/slurm/sample/batchscripts``.
 
-The syntax for **sbatch** is:
-:raw-html:`<br />` :raw-html:`&nbsp` ``sbatch [list of sbatch options] script_name``
+The syntax for submitting a batch job with **sbatch** is:
+::
+
+  sbatch [list of sbatch options] script_name
+
+
 :raw-html:`<br />` 
 :raw-html:`<br />` The main sbatch options are listed below. Also, see the sbatch man page for options.
 
@@ -128,12 +157,17 @@ Accessing the GPUs: To gain access to the GPUs within the batch job’s environm
 
 :raw-html:`<br />` Example:
   :raw-html:`&nbsp` (in a batch script)
-  :raw-html:`<br />` :raw-html:`&nbsp` ``#SBATCH   gres=gpu:tesla_a40``
+  :raw-html:`&nbsp` ::
+
+  #SBATCH   --gres=gpu:tesla_a40
+
 or
   :raw-html:`&nbsp` (on the batch job submission line)
-  :raw-html:`<br />` :raw-html:`&nbsp` ``sbatch … --gres=gpu:tesla_a40 batchscript_name.sbatch``
-  :raw-html:`<br />` :raw-html:`&nbsp`
-  :raw-html:`<br />` :raw-html:`&nbsp`
+  :raw-html:`&nbsp` ::
+
+   sbatch … --gres=gpu:tesla_a40 batchscript_name.sbatch
+
+  
 
 
 **Useful Batch Job Environment Variables**
@@ -161,19 +195,204 @@ or
 
 See the sbatch man page for additional environment variables available.
 
-srun
-----
 
-The srun command initiates an interactive batch job on the compute nodes.
+Sample Batch Scripts
+--------------------
 
-For example, the following command:
+When using Slurm to run your software on the Nightingale compute
+nodes, job instructions and run commands are organized into a
+"batch script". This page gives you hints about composing your own batch
+scripts for Slurm on Nightingale, and it also has some basic batch scripts
+you may copy and use as templates for your own batch scripts. To use the
+examples on this page, we assume that you generally know how to write a
+shell scripts and how they work.
+
+By default, when your batch script is run, it has copies of all the
+environment variables that existed in your shell when you submit (sbatch-ed)
+the batch script to the SLURM batch system. You can control the job behavior
+this way.
+
+Below is a sample batch script that just runs a single serial application
+(hostname). Hostname is not an application that you'd normally run; it's
+here because it's a harmless example that does something very quickly
+and then exits. If you run this script, though, and it works, then you
+know that you have a working script and you can build from there.
+Typically you'd replace "hostname" which some application code that you
+wanted to run to do work on the compute node.
+
 ::
 
-  [ng-login01 ~]$ srun --account=ACCT_NAME --partition=cpu --time=00:30:00 --nodes=1 --ntasks-per-node=16 --pty /bin/bash
+   #!/bin/bash                                                                                                                                                                                               
+   ###############################################################################                                                                                                                           
+   ##                                                                           ##                                                                                                                           
+   ##                   NCSA Nightingale Cluster                                ##                                                                                                                           
+   ##                                                                           ##                                                                                                                           
+   ##                   Sample SERIAL Job Batch Script                          ##                                                                                                                           
+   ##                                                                           ##                                                                                                                           
+   ###############################################################################                                                                                                                           
 
-(where *ACCT_NAME* is the actual name of your charge account) will run an interactive batch job in the cpu partition (queue) with a wall clock limit of *30 minutes*, using *one node* and *16 cores per node*. You can also use other sbatch options such as those documented above.
+   # To see a list of possible #SBATCH options, run "man sbatch" on the                                                                                                                                      
+   # command line.                                                                                                                                                                                           
 
-After you enter the command, you will have to wait for SLURM to start the job. As with any job, your interactive job will wait in the queue until the resources your reqested for your batch job become available.  If you specify a small number of nodes for smaller amounts of time, the wait should be shorter because your job will backfill among larger jobs. You will see output similar to this:
+   # NOTE: option lines that begin with "#SBATCH" (single "#") are active and will                                                                                                                           
+   # be read and implemented by slurm as the job is set up.                                                                                                                                                  
+   # Lines that begin with "##SBATCH" are considered "commented out" and                                                                                                                                     
+   # ignored by slurm.  Both of those are ignored as the job script runs *within*                                                                                                                            
+   # the job.                                                                                                                                                                                                
+
+   # the "-A" directive specifies what "allocation account" your job time will                                                                                                                               
+   # be charged to.  You will need to replace "usrsvc" with the name of your                                                                                                                                 
+   # allocation account                                                                                                                                                                                      
+   #                                                                                                                                                                                                         
+   #SBATCH -A usrsvc                                                                                                                                                                                         
+
+   # other general job parameters                                                                                                                                                                            
+   #SBATCH --time=00:05:00                  # Job run time (hh:mm:ss)                                                                                                                                        
+   #SBATCH --nodes=1                        # Number of nodes                                                                                                                                                
+   #SBATCH --ntasks-per-node=16             # Number of task (cores/ppn) per node                                                                                                                            
+   #SBATCH --job-name=serial_job            # Name of batch job                                                                                                                                              
+   #SBATCH --partition=cpu                  # Partition (queue)                                                                                                                                              
+   #SBATCH --output=serial_%j.out           # stdout from job is written to this file                                                                                                                        
+   #SBATCH --error=serial_%j.err            # stderr from job is written to this file                                                                                                                        
+   ##SBATCH --mail-user=NetID@illinois.edu  # put YOUR email address for notifications                                                                                                                       
+   ##SBATCH --mail-type=BEGIN,END           # Type of email notifications to send                                                                                                                            
+   #                                                                                                                                                                                                         
+   ###############################################################################                                                                                                                           
+   # Change to the directory from which the batch job was submitted                                                                                                                                          
+   # Note: SLURM defaults to running jobs in the directory where                                                                                                                                             
+   # they are submitted, no need for cd'ing to $SLURM_SUBMIT_DIR                                                                                                                                             
+
+   echo
+   echo "running slurm job on Nightingale on behalf of user ${USER}"
+   echo
+   echo "running in directory ${SLURM_SUBMIT_DIR}"
+   echo
+
+   # Run the serial code                                                                                                                                                                                     
+   hostname
+
+| 
+
+The following is a batch script that runs a code in parallel, with a couple of other
+features that are useful in batch jobs:
+
+::
+
+   #!/bin/bash
+   ###############################################################################
+   ##                                                                           ##
+   ##                   NCSA Nightingale Cluster                                ##
+   ##                                                                           ##
+   ##                 Sample PARALLEL Job Batch Script                          ##
+   ##                                                                           ##
+   ###############################################################################
+
+   # To see a list of possible #SBATCH options, run "man sbatch" on the
+   # command line.  
+
+   # NOTE: option lines that begin with "#SBATCH" (single "#") are active and will
+   # be read and implemented by slurm as the job is set up.
+   # Lines that begin with "##SBATCH" are considered "commented out" and
+   # ignored by slurm.  Both of those are ignored as the job script runs *within*
+   # the job.  
+
+   # the "-A" directive specifies what "allocation account" your job time will
+   # be charged to.  You will need to replace "usrsvc" with the name of your
+   # allocation account
+   # 
+   #SBATCH -A usrsvc                        
+
+   # other general job parameters
+   #SBATCH --time=00:05:00                  # Job run time (hh:mm:ss)
+   #SBATCH --nodes=1                        # Number of nodes
+   #SBATCH --ntasks-per-node=16             # Number of task (cores/ppn) per node
+   #SBATCH --job-name=parallel_job          # Name of batch job
+   #SBATCH --partition=cpu                  # Partition (queue)           
+   #SBATCH --output=parallel_%j.out           # stdout from job is written to this file
+   #SBATCH --error=parallel_%j.err            # stderr from job is written to this file
+   ##SBATCH --mail-user=NetID@illinois.edu  # put YOUR email address for notifications
+   ##SBATCH --mail-type=BEGIN,END           # Type of email notifications to send
+   #                                                                            
+   ###############################################################################
+   # Change to the directory from which the batch job was submitted
+   # Note: SLURM defaults to running jobs in the directory where
+   # they are submitted, no need for cd'ing to $SLURM_SUBMIT_DIR
+
+   # your job will create a job-specific directory and then run within that
+   # directory.  This is handy if your application outputs a lot of files
+   # in its local directory and you need to keep them separate by job.  
+   MY_JOB_DIR="parallel_job_${SLURM_JOB_ID}"
+   mkdir ${MY_JOB_DIR}
+   cd ${MY_JOB_DIR}
+   # NOTE: stdout and stderr files will still end up in the original directory
+   # that you ran sbatch in, not the job-specific subdirectory
+
+   echo 
+   echo "running slurm job on Nightingale on behalf of user ${USER}"
+   echo 
+   echo "running in directory ${SLURM_SUBMIT_DIR}"
+   echo 
+
+
+   # set start time stamp
+   touch application_start_time
+   # Run the code in parallel across several cores
+   srun hostname
+   # set end time stamp
+   touch application_end_time
+
+| 
+
+
+
+Additional sample batch scripts are available on Nightingale in the following directory:
+::
+
+  /sw/apps/NUS/slurm/sample/batchscripts
+
+
+
+srun (command line)
+----
+interactive batch job
+_____________________
+
+Rather than queuing up a batch job to run on the compute nodes, you can request
+that the job scheduler allocate you to a compute node **now**, and to log 
+you onto it. These are called interactive batch jobs.
+
+Projects that have dedicated interactive nodes, do not need to go through
+the scheduler. Members of these projects just login directly to thier nodes.
+
+To launch an interactive batch job using the job scheduler with the default
+values for the job resources(nodes,cores,memory,etc ...), run
+the following command:
+
+::
+
+   srun -A usrsvc --pty bash 
+
+(You'll need change "usrsvc" in that command to the name of your
+allocation account.)
+
+**Warning**: be sure to end the interactive job as soon as you're done (by typing 
+*exit*). If you leave the job running, even if you're not running any processes, 
+your allocation account is being charged for the time.
+
+
+To specify resources for your interactive batch job the 
+srun command syntax should look similar to the following:
+::
+
+  srun --account=ACCT_NAME --partition=cpu --time=00:30:00 --nodes=1 --ntasks-per-node=16 --pty /bin/bash
+
+(where *ACCT_NAME* is the actual name of your charge account) will run an
+interactive batch job in the cpu partition (queue) with a wall clock limit
+of *30 minutes*, using *one node* and *16 cores per node*. You can also use
+other sbatch options such as those documented above.
+
+After you enter the command, you will have to wait for SLURM to start the
+job.  You will see output similar to this:
 ::
 
   srun: job 123456 queued and waiting for resources
@@ -187,9 +406,36 @@ Once the job starts, you will see:
 
   srun: job 123456 has been allocated resources
 
-and will be presented with an interactive shell prompt on the launch node. At this point, you can use the appropriate command to start your program.
+and will be presented with an interactive shell prompt on the launch node. At this point, you can use the appropriate command(s) to start your program.
 
-When you are done with your runs, you can use the **exit** command to end the job.
+Again, when you are done with your interactive batch job session, you can use the **exit** command to end the job.
+
+
+srun (batch script)
+----
+
+:raw-html:`<br />` Inside a batch script if you want to run multiple copies of a program you can use the *srun* command followed by the name of the executable. 
+:raw-html:`<br />` :raw-html:`&nbsp`
+:raw-html:`<br />` Ex.
+::
+
+  srun ./a.out
+
+:raw-html:`<br />` :raw-html:`&nbsp`
+:raw-html:`<br />` **Note:** By default the total number of copies run, is equal to number cores specified in the batch job resource specification.
+:raw-html:`<br />` :raw-html:`&nbsp`
+:raw-html:`<br />` Users can use the *-n*  flag/option with the *srun* command to specify the number of copies of a program that they would like to run 
+:raw-html:`<br />` keeping in mind that the value for the *-n*  flag/option must be less than or equal to the number of cores specifed for the batch job.
+:raw-html:`<br />` :raw-html:`&nbsp`
+:raw-html:`<br />` Ex. 
+::
+
+  srun -n 10 ./a.out
+
+:raw-html:`<br />` :raw-html:`&nbsp`
+
+
+
 
 squeue
 ------
@@ -237,9 +483,27 @@ The *sinfo* command is used to view partition and node information for a system 
    * - :raw-html:`<br />` ``sinfo -a`` :raw-html:`<br />`
        :raw-html:`&nbsp`
      - :raw-html:`<br />` List summary information on all the partitions (queues).
+   * - :raw-html:`<br />` ``sinfo -p PRTN_NAME`` :raw-html:`<br />`
+       :raw-html:`&nbsp`
+     - :raw-html:`<br />` Print information only about the specified partition(s). Multiple partitions are separated by commas.
 
+
+:raw-html:`<br />` :raw-html:`&nbsp`
+Users can view the partitions(queues) that they have the ability to submit batch jobs to, by typing the following command:
+::
+
+    [ng-login01 ~]$ sinfo -s -o "%.14R %.12l %.12L %.5D"
+    
+Users can also view specific configuration information about the compute nodes associated with their primary partition(s), by typing the following command:
+::
+
+    [ng-login01 ~]$ sinfo -p queue(partition)_name -N -o "%.8N %.4c %.16P %.9m %.12l %.12L %G"
+
+
+:raw-html:`<br />` :raw-html:`&nbsp`
 Run the command ``man sinfo`` to see the other available options.
 
+:raw-html:`<br />` :raw-html:`&nbsp`
 
 scancel
 -------

--- a/docs/source/software/installed_software.rst
+++ b/docs/source/software/installed_software.rst
@@ -11,17 +11,11 @@ Software           Version
 Anaconda           2022.05  (python 3.9.12)
 awscli             2.4.16
 Cuda               11.4.2
+GCC                12.2.0
 Julia              4.3.2
 MATLAB             9.7
 Miniconda          2022.05  (python 3.9.12)
 R                  4.2.0
 ===========        ========================
 
-Anaconda is a free, open-source distribution of the Python and R programming languages. 
-Anaconda (ver 2022.05) and Miniconda (ver 2022.05) are installed on
-Nightingale. One of the main differences between Anaconda
-and Minconda is the number of packages: Anaconda by default installs
-with over 150 data science packages, whereas Miniconda by default
-installs a subset of the packages installed by default with Anaconda. 
-Anaconda includes Conda, which is a package manager and environment 
-management system. It is a popular package manager for Python and R. 
+

--- a/docs/source/software/python.rst
+++ b/docs/source/software/python.rst
@@ -6,6 +6,17 @@ Introduction
 ============
 Python is an interpreted, high-level, general-purpose programming language. Python and Python packages are available via the `Python Package Index (PyPI) <https://pypi.org/>`_ , which hosts thousands of third-party modules for Python. Both Python’s standard library and the community-contributed modules allow for endless possibilities. Anaconda also provides a Python environment with python packages.
 
+
+Anaconda is a free, open-source distribution of the Python and R programming languages. 
+Anaconda (ver 2022.05) and Miniconda (ver 2022.05) are installed on
+Nightingale. One of the main differences between Anaconda
+and Minconda is the number of packages: Anaconda by default installs
+with over 150 data science packages, whereas Miniconda by default
+installs a subset of the packages installed by default with Anaconda. 
+Anaconda includes Conda, which is a package manager and environment 
+management system. It is a popular package manager for Python and R. 
+
+
 Versions
 ========
 The table below lists the versions of Python installed on the Nightingale.

--- a/docs/source/software/python.rst
+++ b/docs/source/software/python.rst
@@ -44,7 +44,7 @@ installed (including your own installed packages) in your environment::
 
   cd ${HOME}
   module load anaconda3/2022.05
-  export CONDA_PKGS_DIRS="/u/${HOME}/.conda/pkgs"
+  export CONDA_PKGS_DIRS="${HOME}/.conda/pkgs"
   conda create -n my.anaconda python
   conda info -e
   source activate my.anaconda
@@ -54,15 +54,15 @@ installed (including your own installed packages) in your environment::
  
 To deactivate the anaconda environment type::
 
- conda deactivate
+  conda deactivate
 
 To create a complete clone anaconda environment replace::
 
- conda create -n my.anaconda python
+  conda create -n my.anaconda python
  
 with::
 
- conda create -n my.anaconda anaconda
+  conda create -n my.anaconda anaconda
 
 Viewing Installed Python Packages
 =================================

--- a/docs/source/software/python.rst
+++ b/docs/source/software/python.rst
@@ -43,8 +43,8 @@ The following commands will create a minimal clone anaconda environment in your 
 installed (including your own installed packages) in your environment::
 
   cd ${HOME}
-  module load anaconda/2022-May/3
-  export ${HOME}/.conda/pkgs
+  module load anaconda3/2022.05
+  export CONDA_PKGS_DIRS="/u/${HOME}/.conda/pkgs"
   conda create -n my.anaconda python
   conda info -e
   source activate my.anaconda

--- a/docs/source/software/python.rst
+++ b/docs/source/software/python.rst
@@ -50,7 +50,7 @@ You must install software/libraries into user-writeable locations like your home
 Generally, any Python package not available in the system installation can be 
 installed from the `Python Package Index <https://pypi.org/>`_ (PyPI)  in your specified location.
 
-The following commands will create a minimal clone anaconda environment in your scratch directory, install pytorch, and list the Python packages 
+The following commands will create a minimal clone anaconda environment in your home directory, install pytorch, and list the Python packages 
 installed (including your own installed packages) in your environment::
 
   cd ${HOME}

--- a/docs/source/software/using_r.rst
+++ b/docs/source/software/using_r.rst
@@ -69,7 +69,7 @@ Using Rscript
 
 You can use the rscript command to run R commands without starting an R session. As a scripting front end for R, Rscript enables using R via shell scripts and scripting applications.
 
-The examples below show step-by-step the commands you can run on the Nightingale. In these steps, ~/Rlibs is used for the location to install user-specific add-on packages (The tilde "~" means the users' home directory—i.e. $HOME).
+The examples below show step-by-step the commands you can run on Nightingale. In these steps, ~/Rlibs is used for the location to install user-specific add-on packages (The tilde "~" means the users' home directory—i.e. $HOME).
 
 **Note:** These examples use the BASH shell. The command syntax may differ when using a different shell.
 

--- a/docs/source/visualization.rst
+++ b/docs/source/visualization.rst
@@ -3,4 +3,4 @@ Visualization
 ====================
 
 The ability for users to do data visualization on Nightingale is not currently available. In the meantime, if 
-you need this capability, send email to help@ncsa.illinois.edu.
+you need this capability, send us a ticket: :ref:`help` and ask us about it.


### PR DESCRIPTION
Visualization here: 
https://ncsa-nightingale.readthedocs-hosted.com/en/doc_rollout_nov30/

This contains everything except one commit from the proposed changes branch, including the change from Sandie removing the "sample scripts" from the TOC, and the three pages from Weddie reorganizing those pages including the sample scripts.  

This also includes one quick tweak that Weddie made, and I change the email links on some of the pages to links to the global Help page (so that they'll see the subject line and the other instructions).  

@wjackson-gh Can you double check this and then review it, and approve it if it's what it should be.  