### PR TITLE
Correct settings for HTTPS_PROXY & R_LIBS env vars

### DIFF
--- a/docs/source/file_mgmt/transfer_files.rst
+++ b/docs/source/file_mgmt/transfer_files.rst
@@ -55,6 +55,5 @@ Copying Files Off of Nightingale
 
 Any method that can transfer data to Nightingale can also be used to transfer information off of the machine. 
 
-However, before doing so please read about :ref:`Protected Data`.
-
+However, before doing so please read about `protected data <../protected_data.rst>`_.
 Data transfers off of Nightingale are audited and must be accounted for.

--- a/docs/source/file_mgmt/transfer_files.rst
+++ b/docs/source/file_mgmt/transfer_files.rst
@@ -50,4 +50,11 @@ In order to use AWS S3 Buckets you must first configure the service. Run the com
 
 Copy files from the bucket using::
 
-   aws s3 cp s3://<bucket-name> <local name on nightingale>
+Copying Files Off of Nightingale
+=========================================
+
+Any method that can transfer data to Nightingale can also be used to transfer information off of the machine. 
+
+However, before doing so please read about :ref:`Protected Data`.
+
+Data transfers off of Nightingale are audited and must be accounted for.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,7 @@ Contents
    citizenship
    file_mgmt/index
    software/index
+   programming_environment
    running_jobs/index
    visualization
    containers

--- a/docs/source/not_used/adding_software.rst
+++ b/docs/source/not_used/adding_software.rst
@@ -46,7 +46,7 @@ these tools:
 
 ::
 
-    export https_proxy=\ https://ache-proxy.ncsa.illinois.edu:3128
+    export HTTPS_PROXY=http://ache-proxy.ncsa.illinois.edu:3128
 
 This sets the auto-install tool to access the outside internet through a
 network proxy, which allows connections to limited outside network

--- a/docs/source/programming_environment
+++ b/docs/source/programming_environment
@@ -4,7 +4,7 @@ Programming Environment
 
 
 The GNU compilers (GCC) version 8.4.1 are in the default user environment. Version 12.2.0 is also available — load this version with the command:
-
+::
 module load gcc/12.2.0
 
 
@@ -94,7 +94,7 @@ CUDA
 NVIDIA GPUs are available as part of the Nightingale compute cluster. CUDA is a parallel computing platform and programming model from NVIDIA for use on the GPUs. These GPUs support CUDA compute capability 2.0.
 
 Load the CUDA Toolkit into your environment using the following module command:
-
+::
 module load cuda/11.4.2
 
 

--- a/docs/source/programming_environment
+++ b/docs/source/programming_environment
@@ -1,0 +1,101 @@
+#######################
+Programming Environment
+#######################
+
+
+The GNU compilers (GCC) version 8.4.1 are in the default user environment. Version 12.2.0 is also available — load this version with the command:
+
+module load gcc/12.2.0
+
+
+Compiler Commands
+
+Serial
+To build (compile and link) a serial program in Fortran, C, and C++ enter:
+
+.. role:: raw-html(raw)
+    :format: html
+
+.. list-table:: 
+   :widths: 25 25 50
+   :header-rows: 1
+
+
+   * - GCC
+   * - :raw-html:`<br />` ``gfortran myprog.f``   :raw-html:`<br />`
+       :raw-html:`<br />` ``gfortran myprog.f90`` :raw-html:`<br />`
+       :raw-html:`<br />` ``     gcc myprog.c``    :raw-html:`<br />`
+       :raw-html:`<br />` ``     g++ myprog.cc``  :raw-html:`<br />`
+
+
+MPI
+To build (compile and link) a MPI program in Fortran, C, and C++:
+
+.. role:: raw-html(raw)
+    :format: html
+
+.. list-table:: 
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - MPI Implementation
+     - modulefile for MPI/Compiler
+     - Build Commands
+   * - :raw-html:`<br />` Open MPI :raw-html:`<br />`
+       :raw-html:`&nbsp` (Home Page / Documentation) :raw-html:`<br />`
+     - :raw-html:`<br />` openmpi/4.1.4-gcc
+     - :raw-html:`<br />` ``Fortran 77:  mpif77 myprog.f``   :raw-html:`<br />`
+       :raw-html:`<br />` ``Fortran 90:  mpif90 myprog.f90`` :raw-html:`<br />`
+       :raw-html:`<br />` ``         C:  mpicc myprog.c``    :raw-html:`<br />`
+       :raw-html:`<br />` ``       C++:  mpicxx myprog.cc``  :raw-html:`<br />`
+
+
+
+OpenMP
+To build an OpenMP program, use the -fopenmp / -qopenmp option:
+
+.. role:: raw-html(raw)
+    :format: html
+
+.. list-table:: 
+   :widths: 25 25 50
+   :header-rows: 1
+
+
+   * - GCC
+   * - :raw-html:`<br />` ``gfortran -fopenmp myprog.f``   :raw-html:`<br />`
+       :raw-html:`<br />` ``gfortran -fopenmp myprog.f90`` :raw-html:`<br />`
+       :raw-html:`<br />` ``     gcc -fopenmp myprog.c``    :raw-html:`<br />`
+       :raw-html:`<br />` ``     g++ -fopenmp myprog.cc``  :raw-html:`<br />`
+ 
+
+
+Hybrid MPI/OpenMP
+To build an MPI/OpenMP hybrid program, use the -fopenmp / -qopenmp option with the MPI compiling commands:
+
+.. role:: raw-html(raw)
+    :format: html
+
+.. list-table:: 
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - GCC
+   * - OpenMPI
+   * - :raw-html:`<br />` ``mpif77 -fopenmp myprog.f``   :raw-html:`<br />`
+       :raw-html:`<br />` ``mpif90 -fopenmp myprog.f90`` :raw-html:`<br />`
+       :raw-html:`<br />` `` mpicc -fopenmp myprog.c``   :raw-html:`<br />`
+       :raw-html:`<br />` ``mpicxx -fopenmp myprog.cc``  :raw-html:`<br />`
+ 
+
+
+
+CUDA
+NVIDIA GPUs are available as part of the Nightingale compute cluster. CUDA is a parallel computing platform and programming model from NVIDIA for use on the GPUs. These GPUs support CUDA compute capability 2.0.
+
+Load the CUDA Toolkit into your environment using the following module command:
+
+module load cuda/11.4.2
+
+
+

--- a/docs/source/software/using_r.rst
+++ b/docs/source/software/using_r.rst
@@ -73,19 +73,23 @@ The examples below show step-by-step the commands you can run on Nightingale. In
 
 **Note:** These examples use the BASH shell. The command syntax may differ when using a different shell.
 
-**Step 1:** Create a directory for your R packages::
+**Step 1:** Set the HTTPS_PROXY environment variable (if you have not already done so).
+
+  export HTTPS_PROXY=http://ache-proxy.ncsa.illinois.edu:3128
+
+**Step 2:** Create a directory for your R packages::
 
    mkdir ~/Rlibs
 
-**Step 2:** Load the R modulefile::
+**Step 3:** Load the R modulefile::
  
    module load R/4.2.0
 
-**Step 3:** Set the R library environment variable (R_LIBS) to include your R package directory::
+**Step 4:** Set the R library environment variable (R_LIBS) to include your R package directory::
 
-  export R_LIBS=~/Rlibs
+  export R_LIBS=~/Rlibs:$R_LIBS
 
-**Step 4:** Use the install.packages command to install your R package::
+**Step 5:** Use the install.packages command to install your R package::
 
   Rscript -e "install.packages('RCurl', '~/Rlibs', 'https://cran.r-project.org')"
 


### PR DESCRIPTION
Add a step to set the HTTPS_PROXY environment variable so that a R packages can be downloaded directly from cran.r-project.org to NG.  Also correctly set the R_LIBS environment variable.