### PR TITLE
fixed inf, new accts page

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,6 @@
+version: 2
+
+build:
+os: ubuntu-22.04
+tools:
+python: "3.11"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,3 +4,13 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+
+# Build from the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Explicitly set the version of Python and its requirements
+python:
+  install:
+    - requirements: docs/requirements.txt
+    

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,6 @@
 version: 2
 
 build:
-os: ubuntu-22.04
-tools:
-python: "3.11"
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+# Defining the exact version will make sure things don't break
+sphinx<6

--- a/docs/source/accessing/getting_acct.rst
+++ b/docs/source/accessing/getting_acct.rst
@@ -21,14 +21,14 @@ Discuss Your Project With Nightingale Management
 ----------------------------------------------------
 
 Before getting your project added to the Nightingale system, you will need to discuss your project, its needs, your expectations, and what Nightingale access can get you.  To begin that conversation, please fill out `the NCSA XRAS <https://xras-submit.ncsa.illinois.edu/opportunities/531957/requests/new>`_.  Someone from the Nightingale project will contact you via email within a few days of filling out this form.  That person will begin the process of creating your project group.  During that process, *you* will be responsible for:
+
 * Becoming part of the NCSA HIPAA Covered Entity
   * this in turn involves taking training specific 
   * you may need to submit your training certificate to a web for to become part of the covered entity
 * Making sure all devices that you will log into Nightingale from have an encrypted hard drive
 
 The following will be happening on Nightingale on your behalf 
+
 * Your project group will be created
 * your project may be assigned a node or part of a node (interactive node access)
 * your project may be granted access to the batch computing system (batch system access)
-
-

--- a/docs/source/accessing/getting_acct.rst
+++ b/docs/source/accessing/getting_acct.rst
@@ -15,19 +15,20 @@ If you don’t remember your password, you can reset it on the `NCSA Identity an
 - **To create an NCSA identity**, go to this `invite link <https://go.ncsa.illinois.edu/ngale_identity>`_
 
 **Note:** In addition to creating a new account, this process will automatically enroll you into NCSA's Duo multi-factor 
-authentication (https://go.ncsa.illinois.edu/2fa), which is required to log into Nightingale. (This is not the same as the University of Illnois's Duo.)
+authentication (https://go.ncsa.illinois.edu/2fa), which is required to log into Nightingale. (This is not the same as the University of Illnois's Duo.).  When you enroll in NCSA Duo, it's **very important** create and save two backup codes to use in case you lose your Duo device.  
 
-Request Project Group
-----------------------------
+Discuss Your Project With Nightingale Management
+----------------------------------------------------
 
-If your project hasn't been added to Nightingale yet, your PI needs to make a request for a project to be created for it. Once the form is completed they should get a response in a couple of days.
+Before getting your project added to the Nightingale system, you will need to discuss your project, its needs, your expectations, and what Nightingale access can get you.  To begin that conversation, please fill out `the NCSA XRAS <https://xras-submit.ncsa.illinois.edu/opportunities/531957/requests/new>`_.  Someone from the Nightingale project will contact you via email within a few days of filling out this form.  That person will begin the process of creating your project group.  During that process, *you* will be responsible for:
+* Becoming part of the NCSA HIPAA Covered Entity
+  * this in turn involves taking training specific 
+  * you may need to submit your training certificate to a web for to become part of the covered entity
+* Making sure all devices that you will log into Nightingale from have an encrypted hard drive
 
-- **To create a project group**, use this form `(authenticating with your NCSA identity) <https://xras-submit.ncsa.illinois.edu/opportunities/531957/requests/new>`_
+The following will be happening on Nightingale on your behalf 
+* Your project group will be created
+* your project may be assigned a node or part of a node (interactive node access)
+* your project may be granted access to the batch computing system (batch system access)
 
-Someone from the Nightingale project will contact you via email within a few days of filling out this form.  They will begin the process.  You will then receive emails pointing you to things like: 
 
-- Taking training appropriate for your project
-- Becoming part of the NCSA HIPAA Covered Entity
-- Having your project group created
-
-After that happens, you (or your PI) will need to create your login account attached to your project group, and then you'll have access to Nightingale.  

--- a/docs/source/accessing/getting_acct.rst
+++ b/docs/source/accessing/getting_acct.rst
@@ -6,7 +6,7 @@ To access Nightingale, your project needs to have a project group on the machine
 Once approved, you will be given instructions on how to be added to NCSA's HIPAA Covered Entity. 
 The steps below explain this process.
 
-#. Create an NCSA Identity
+Create an NCSA Identity
 ----------------------------
 
 Before requesting Nightingale access, you need an NCSA identity. You can skip this step if you already have an NCSA identity. 
@@ -17,19 +17,28 @@ If you don’t remember your password, you can reset it on the `NCSA Identity an
 **Note:** In addition to creating a new account, this process will automatically enroll you into NCSA's Duo multi-factor 
 authentication (https://go.ncsa.illinois.edu/2fa), which is required to log into Nightingale. (This is not the same as the University of Illnois's Duo.)
 
-#. Request Project Group
+Request Project Group
 ----------------------------
 
 If your project hasn't been added to Nightingale yet, your PI needs to make a request for a project to be created for it. Once the form is completed they should get a response in a couple of days.
 
 - **To create a project group**, use this form `(authenticating with your NCSA identity) <https://xras-submit.ncsa.illinois.edu/opportunities/531957/requests/new>`_
 
-#. Request Nightingale Access
+Someone from the Nightingale project will contact you via email within a few days of filling out this form.  They will begin the process.  You will then receive emails pointing you to things like: 
+
+- Taking training appropriate for your project
+- Becoming part of the NCSA HIPAA Covered Entity
+- Having your project group created
+
+After that happens, you (or your PI) will need to create your login account attached to your project group, and then you'll have access to Nightingale.  
+
+"""
+Request Nightingale Access
 ---------------------------------
 
 - **To request Nightingale access**, send an email to  `help+hipaa@ncsa.illinois.edu <mailto:help+hipaa@ncsa.illinois.edu>`_ that includes your NCSA identity, your University UIN, and a brief description of why you want the access. Please attach your training certificate if you completed sensitive, regulated data training less than a year ago (HIPAA, CUI, or otherwise).
 
-#. Get Added to NCSA's HIPAA Covered Entity
+Get Added to NCSA's HIPAA Covered Entity
 -----------------------------------------------
 
 The University of Illinois’ HIPAA Privacy and Security Directive requires that all members of a covered entity complete HIPAA training on an annual basis and perform endpoint disk encryption of portable devices (like laptops) used to access, process, or store HIPAA sensitive, regulated data. Your email request in Step 2 starts the process of getting added to NCSA's HIPAA Covered Entity required to access Nightingale.
@@ -38,7 +47,8 @@ The University of Illinois’ HIPAA Privacy and Security Directive requires that
 
 **Note:** You may request an exemption from the encryption requirement in cases such as if you plan to use an on-site work desktop.
 
-#. Get Added to Your Project's Group
+Get Added to Your Project's Group
 -------------------------------------
 
 After completing Steps 1 - 3, NCSA will add you to your project’s group, giving you access to the system. If the group doesn’t exist yet, it can take a few days to create it.
+"""

--- a/docs/source/accessing/getting_acct.rst
+++ b/docs/source/accessing/getting_acct.rst
@@ -1,15 +1,13 @@
 Getting an Account
 ====================
 
-To access Nightingale, your project needs to have a project group on the machine, you must get an NCSA Identity 
-(username and password), and request access from Nightingale administrators. 
-Once approved, you will be given instructions on how to be added to NCSA's HIPAA Covered Entity. 
-The steps below explain this process.
+To access Nightingale, your project needs to have a "project group" set up with access to Nightingale, and associated with the various resources that you need to use.  The project's Principle Investigator ("PI") sets up the project group, and the PI's user login account will be the first login accout attached to the project group.  The PI must have an NCSA Identity 
+(username and password) or get one, and request access from Nightingale administrators.  This page covers that process.  The project PI will need to follow the process of creating the project group, and themselves go through the training process and be added to the HIPAA Covered Entity.  Other users on the project will just need to follow the training and Covered Entity process.  This page covers both processes.  
 
 Create an NCSA Identity
 ----------------------------
 
-Before requesting Nightingale access, you need an NCSA identity. You can skip this step if you already have an NCSA identity. 
+Before requesting Nightingale access, both PIs and individual users need an NCSA identity. You can skip this step if you already have an NCSA identity. 
 If you don’t remember your password, you can reset it on the `NCSA Identity and Access Management webpage <https://identity.ncsa.illinois.edu/>`_.
 
 - **To create an NCSA identity**, go to this `invite link <https://go.ncsa.illinois.edu/ngale_identity>`_
@@ -20,7 +18,13 @@ authentication (https://go.ncsa.illinois.edu/2fa), which is required to log into
 Discuss Your Project With Nightingale Management
 ----------------------------------------------------
 
-Before getting your project added to the Nightingale system, you will need to discuss your project, its needs, your expectations, and what Nightingale access can get you.  To begin that conversation, please fill out `the NCSA XRAS <https://xras-submit.ncsa.illinois.edu/opportunities/531957/requests/new>`_.  Someone from the Nightingale project will contact you via email within a few days of filling out this form.  That person will begin the process of creating your project group.  
+(Individual users don't need to follow this step.).  Before getting your project added to the Nightingale system, a PI will need to discuss your project, its needs, your expectations, and what Nightingale access can get you.  To begin that conversation, please fill out `the NCSA XRAS <https://xras-submit.ncsa.illinois.edu/opportunities/531957/requests/new>`_.  Someone from the Nightingale project will contact you via email within a few days of filling out this form.  That person will begin the process of creating your project group.  
+
+After your project group is created, Nightingale adminstirators will create your data storage directories and project group name.  The PI will find out about these steps via email.  Your group will be assigned an interactive node (shared or exclusive) to log into, and/or if you have batch system access, you will be assigned a "charge account" to assign your jobs to.  
+
+Being Added to Nightingale Access
+-------------------------------------
+Both PIs creating a new project and individual users joining a project will need to follow these steps to get their user login accounts access to the Nightingale system.  
 
 During that process, *you* will be responsible for:
 
@@ -31,11 +35,3 @@ During that process, *you* will be responsible for:
   * you may need to submit your training certificate to a web form to become part of the covered entity
 
 * Making sure all devices that you will log into Nightingale from have an encrypted hard drive
-
-The following will be happening on Nightingale on your behalf 
-
-* Your project group will be created
-
-* your project may be assigned a node or part of a node (interactive node access)
-
-* your project may be granted access to the batch computing system (batch system access)

--- a/docs/source/accessing/getting_acct.rst
+++ b/docs/source/accessing/getting_acct.rst
@@ -23,12 +23,17 @@ Discuss Your Project With Nightingale Management
 Before getting your project added to the Nightingale system, you will need to discuss your project, its needs, your expectations, and what Nightingale access can get you.  To begin that conversation, please fill out `the NCSA XRAS <https://xras-submit.ncsa.illinois.edu/opportunities/531957/requests/new>`_.  Someone from the Nightingale project will contact you via email within a few days of filling out this form.  That person will begin the process of creating your project group.  During that process, *you* will be responsible for:
 
 * Becoming part of the NCSA HIPAA Covered Entity
+
   * this in turn involves taking training specific 
+  
   * you may need to submit your training certificate to a web for to become part of the covered entity
+
 * Making sure all devices that you will log into Nightingale from have an encrypted hard drive
 
 The following will be happening on Nightingale on your behalf 
 
 * Your project group will be created
+
 * your project may be assigned a node or part of a node (interactive node access)
+
 * your project may be granted access to the batch computing system (batch system access)

--- a/docs/source/accessing/getting_acct.rst
+++ b/docs/source/accessing/getting_acct.rst
@@ -7,7 +7,7 @@ To access Nightingale, your project needs to have a project group on the machine
 Once approved, you will be given instructions on how to be added to NCSA's HIPAA Covered Entity. 
 The steps below explain this process.
 
-**1. Create an NCSA Identity**
+**#. Create an NCSA Identity**
 
 Before requesting Nightingale access, you need an NCSA identity. You can skip this step if you already have an NCSA identity. 
 If you don’t remember your password, you can reset it on the `NCSA Identity and Access Management webpage <https://identity.ncsa.illinois.edu/>`_.
@@ -17,17 +17,17 @@ If you don’t remember your password, you can reset it on the `NCSA Identity an
 **Note:** In addition to creating a new account, this process will automatically enroll you into NCSA's Duo multi-factor 
 authentication (https://go.ncsa.illinois.edu/2fa), which is required to log into Nightingale. (This is not the same as the University of Illnois's Duo.)
 
-**2. Request Project Group**
+**#. Request Project Group**
 
 If your project hasn't been added to Nightingale yet, your PI needs to make a request for a project to be created for it. Once the form is completed they should get a response in a couple of days.
 
 - **To create a project group**, use this form `(authenticating with your NCSA identity) <https://xras-submit.ncsa.illinois.edu/opportunities/531957/requests/new>`_
 
-**3. Request Nightingale Access**
+**#. Request Nightingale Access**
 
 - **To request Nightingale access**, send an email to  `help+hipaa@ncsa.illinois.edu <mailto:help+hipaa@ncsa.illinois.edu>`_ that includes your NCSA identity, your University UIN, and a brief description of why you want the access. Please attach your training certificate if you completed sensitive, regulated data training less than a year ago (HIPAA, CUI, or otherwise).
 
-**4. Get Added to NCSA's HIPAA Covered Entity**
+**#. Get Added to NCSA's HIPAA Covered Entity**
 
 The University of Illinois’ HIPAA Privacy and Security Directive requires that all members of a covered entity complete HIPAA training on an annual basis and perform endpoint disk encryption of portable devices (like laptops) used to access, process, or store HIPAA sensitive, regulated data. Your email request in Step 2 starts the process of getting added to NCSA's HIPAA Covered Entity required to access Nightingale.
 
@@ -35,6 +35,6 @@ The University of Illinois’ HIPAA Privacy and Security Directive requires that
 
 **Note:** You may request an exemption from the encryption requirement in cases such as if you plan to use an on-site work desktop.
 
-**5. Get Added to Your Project's Group**
+**#. Get Added to Your Project's Group**
 
 After completing Steps 1 - 3, NCSA will add you to your project’s group, giving you access to the system. If the group doesn’t exist yet, it can take a few days to create it.

--- a/docs/source/accessing/getting_acct.rst
+++ b/docs/source/accessing/getting_acct.rst
@@ -31,24 +31,3 @@ Someone from the Nightingale project will contact you via email within a few day
 - Having your project group created
 
 After that happens, you (or your PI) will need to create your login account attached to your project group, and then you'll have access to Nightingale.  
-
-"""
-Request Nightingale Access
----------------------------------
-
-- **To request Nightingale access**, send an email to  `help+hipaa@ncsa.illinois.edu <mailto:help+hipaa@ncsa.illinois.edu>`_ that includes your NCSA identity, your University UIN, and a brief description of why you want the access. Please attach your training certificate if you completed sensitive, regulated data training less than a year ago (HIPAA, CUI, or otherwise).
-
-Get Added to NCSA's HIPAA Covered Entity
------------------------------------------------
-
-The University of Illinois’ HIPAA Privacy and Security Directive requires that all members of a covered entity complete HIPAA training on an annual basis and perform endpoint disk encryption of portable devices (like laptops) used to access, process, or store HIPAA sensitive, regulated data. Your email request in Step 2 starts the process of getting added to NCSA's HIPAA Covered Entity required to access Nightingale.
-
-- **To get added to NCSA's HIPAA Covered Entity**, follow the instructions in the automated emails from both HIPAA Tools in Savannah and JIRA you will recieve in response to the email you sent in Step 2. These instructions will include information on accessing the HIPAA training, submitting your completion certificate, and performing disk encryption. (The instructions will connect you with NCSA personnel, who will guide you through the encryption process.)
-
-**Note:** You may request an exemption from the encryption requirement in cases such as if you plan to use an on-site work desktop.
-
-Get Added to Your Project's Group
--------------------------------------
-
-After completing Steps 1 - 3, NCSA will add you to your project’s group, giving you access to the system. If the group doesn’t exist yet, it can take a few days to create it.
-"""

--- a/docs/source/accessing/getting_acct.rst
+++ b/docs/source/accessing/getting_acct.rst
@@ -20,13 +20,15 @@ authentication (https://go.ncsa.illinois.edu/2fa), which is required to log into
 Discuss Your Project With Nightingale Management
 ----------------------------------------------------
 
-Before getting your project added to the Nightingale system, you will need to discuss your project, its needs, your expectations, and what Nightingale access can get you.  To begin that conversation, please fill out `the NCSA XRAS <https://xras-submit.ncsa.illinois.edu/opportunities/531957/requests/new>`_.  Someone from the Nightingale project will contact you via email within a few days of filling out this form.  That person will begin the process of creating your project group.  During that process, *you* will be responsible for:
+Before getting your project added to the Nightingale system, you will need to discuss your project, its needs, your expectations, and what Nightingale access can get you.  To begin that conversation, please fill out `the NCSA XRAS <https://xras-submit.ncsa.illinois.edu/opportunities/531957/requests/new>`_.  Someone from the Nightingale project will contact you via email within a few days of filling out this form.  That person will begin the process of creating your project group.  
+
+During that process, *you* will be responsible for:
 
 * Becoming part of the NCSA HIPAA Covered Entity
 
-  * this in turn involves taking training specific 
+  * this will involve taking training specific to the type of data that you'll be handling on Nightingale
   
-  * you may need to submit your training certificate to a web for to become part of the covered entity
+  * you may need to submit your training certificate to a web form to become part of the covered entity
 
 * Making sure all devices that you will log into Nightingale from have an encrypted hard drive
 

--- a/docs/source/accessing/getting_acct.rst
+++ b/docs/source/accessing/getting_acct.rst
@@ -1,13 +1,13 @@
-##################
 Getting an Account
-##################
+====================
 
 To access Nightingale, your project needs to have a project group on the machine, you must get an NCSA Identity 
 (username and password), and request access from Nightingale administrators. 
 Once approved, you will be given instructions on how to be added to NCSA's HIPAA Covered Entity. 
 The steps below explain this process.
 
-**#. Create an NCSA Identity**
+#. Create an NCSA Identity
+----------------------------
 
 Before requesting Nightingale access, you need an NCSA identity. You can skip this step if you already have an NCSA identity. 
 If you don’t remember your password, you can reset it on the `NCSA Identity and Access Management webpage <https://identity.ncsa.illinois.edu/>`_.
@@ -17,17 +17,20 @@ If you don’t remember your password, you can reset it on the `NCSA Identity an
 **Note:** In addition to creating a new account, this process will automatically enroll you into NCSA's Duo multi-factor 
 authentication (https://go.ncsa.illinois.edu/2fa), which is required to log into Nightingale. (This is not the same as the University of Illnois's Duo.)
 
-**#. Request Project Group**
+#. Request Project Group
+----------------------------
 
 If your project hasn't been added to Nightingale yet, your PI needs to make a request for a project to be created for it. Once the form is completed they should get a response in a couple of days.
 
 - **To create a project group**, use this form `(authenticating with your NCSA identity) <https://xras-submit.ncsa.illinois.edu/opportunities/531957/requests/new>`_
 
-**#. Request Nightingale Access**
+#. Request Nightingale Access
+---------------------------------
 
 - **To request Nightingale access**, send an email to  `help+hipaa@ncsa.illinois.edu <mailto:help+hipaa@ncsa.illinois.edu>`_ that includes your NCSA identity, your University UIN, and a brief description of why you want the access. Please attach your training certificate if you completed sensitive, regulated data training less than a year ago (HIPAA, CUI, or otherwise).
 
-**#. Get Added to NCSA's HIPAA Covered Entity**
+#. Get Added to NCSA's HIPAA Covered Entity
+-----------------------------------------------
 
 The University of Illinois’ HIPAA Privacy and Security Directive requires that all members of a covered entity complete HIPAA training on an annual basis and perform endpoint disk encryption of portable devices (like laptops) used to access, process, or store HIPAA sensitive, regulated data. Your email request in Step 2 starts the process of getting added to NCSA's HIPAA Covered Entity required to access Nightingale.
 
@@ -35,6 +38,7 @@ The University of Illinois’ HIPAA Privacy and Security Directive requires that
 
 **Note:** You may request an exemption from the encryption requirement in cases such as if you plan to use an on-site work desktop.
 
-**#. Get Added to Your Project's Group**
+#. Get Added to Your Project's Group
+-------------------------------------
 
 After completing Steps 1 - 3, NCSA will add you to your project’s group, giving you access to the system. If the group doesn’t exist yet, it can take a few days to create it.


### PR DESCRIPTION
This contains some fixes to the readthedocs infrastructure, to compensate for a library that got out of date and then changing the sphinx version so that search still works. 

This also has the latest changes to the "how to create an account" page.  This brings this roughtly up to the current process and also has an attempt to separate PI's required actions from non-PI users.  

This page has been reviewed and approved by Doug.