### PR TITLE
Formatting fix

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -22,11 +22,12 @@ body > div > nav > div > div.wy-side-nav-search > a:hover{
 }
 
 
-/* Clicking on the NCSA logo does nothing (disable RTD theme's default <a> behavior) */
+/* Clicking on the NCSA logo does nothing (disable RTD theme's default <a> behavior) 
 body > div > nav > div > div.wy-side-nav-search > a{
     pointer-events: none;
     cursor: default;
-}
+} */
+
 
 /* making "System Documentation Hub" link visited color the same as unvisited */
 body > div > section > div > div > div:nth-child(1) > ul > li.wy-breadcrumbs-aside > a:visited{

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ html_js_files = [
 html_static_path = ['_static']
 html_logo = "images/BlockI-NCSA-Full-Color-RGB_border4.png"
 html_theme_options = {
-     'logo_only': True,
+     'logo_only': False,
      'display_version': False,
  }
 


### PR DESCRIPTION
This PR re-adds the doc title to the top of the left nav menu. discovered that without it, it's hard to tell what doc set you're in once you leave the landing page.