### PR TITLE
Theme Updates to address 10/7 RTD Addons Update

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # Defining the exact version will make sure things don't break
 #sphinx<6
-sphinx-rtd-theme>1.2
+sphinx-rtd-theme==2.1.0rc2
 
 
 # Adding sphinx-tabs extension

--- a/docs/source/_templates/footer.html
+++ b/docs/source/_templates/footer.html
@@ -3,6 +3,13 @@
 {% extends '!footer.html' %}
 
 {% block extrafooter %} {{super}}
+      <!-- Adding GitHub link start-->
+      {% if display_github %}
+          <a href="https://github.com/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst">
+          View on GitHub.</a>
+      {% endif %}
+      <!-- Adding GitHub link end -->
+
       <!-- OneTrust Cookies Settings button start -->
       <button id="cookie-button" class="ot-sdk-show-settings">About Cookies</button>
       <!-- OneTrust Cookies Settings button end -->

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,29 @@ author = 'NCSA'
 release = '0.1'
 version = '0.1.0'
 
+# RTD recommended config file additions
+
+import os
+
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
+# Restoring GitHub link
+
+html_context = {
+    "display_github": True, # Integrate GitHub
+    "github_user": "ncsa", # Username
+    "github_repo": "Nightingale_real", # Repo name
+    "github_version": os.environ.get("READTHEDOCS_GIT_IDENTIFIER"),  # Version
+    "conf_py_path": "/docs/source/", # Path in the checkout to the docs root
+}
+
 # -- General configuration
 
 extensions = [
@@ -52,6 +75,7 @@ html_logo = "images/BlockI-NCSA-Full-Color-RGB_border4.png"
 html_theme_options = {
      'logo_only': False,
      'display_version': False,
+     'flyout_display': 'attached',
  }
 
 # -- Page Title


### PR DESCRIPTION
These theme changes adjust for the 10/7 RTD Addons Update.
	•	Adds back the bottom-left flyout menu.
	•	Adds back the top-right Documentation Hub link.
	•	Adds 'View on GitHub' to the footer because, per RTD support, it has been removed from the flyout menu and there are no plans to add it back.

RTD build: https://docs.ncsa.illinois.edu/systems/nightingale/en/theme-updates/

Will look into other potential improvements to implement now that this new Addons feature is enabled, but for now, just working on getting doc sets as close to where they were before this update was implemented.