### PR TITLE
Fixing google analytics

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,6 @@ sphinx-tabs
 
 # Adding sphinx-copybutton extension
 sphinx-copybutton
+
+#Adding googleanalytics extension
+sphinxcontrib-googleanalytics

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx_tabs.tabs',
     'sphinx_copybutton',
+    'sphinxcontrib.googleanalytics',
 ]
 
 intersphinx_mapping = {
@@ -80,3 +81,6 @@ html_theme_options = {
 
 # -- Page Title
 html_title = 'UIUC NCSA Nightingale User Guide'
+
+# -- Google Analytics ID
+googleanalytics_id = 'G-JG0GFE04G8'


### PR DESCRIPTION
Adding google analytics extension (sphinxcontrib-googleanalytics). GA link no longer built in to RTD build, this is the extension that RTD support recommended.