### PR TITLE
Modified wording for File and Directory permissions

### DIFF
--- a/docs/source/user_guide/file_mgmt.rst
+++ b/docs/source/user_guide/file_mgmt.rst
@@ -67,7 +67,7 @@ File and Directory Permissions
 
 When you create files or directories on Nightingale, **do not grant permissions to "others"**; this includes read, write, *or* execute. You can set "owner" and "group" permissions to meet your needs. For more information on Linux file permissions, review `Linux file permissions explained <https://www.redhat.com/sysadmin/linux-file-permissions-explained>`_.
 
-File and directory permissions on Nightingale are monitored to maintain the integrity of protected data on the system. If you grant file permissions to "others", system admins will be alerted, and you will be contacted to investigate.
+File and directory permissions on Nightingale are monitored to maintain the integrity of protected data on the system. If you grant file permissions to "others", system admins will be alerted, and the file permissions will be modified to remove those permissions. If this happens repeatedly you will be contacted to investigate the cause.
 
 .. _transfer:
 


### PR DESCRIPTION
Changed the text to let the users know that the file permissions would be modified to remove "other" access when found.